### PR TITLE
Workaround for various Windows compiler bugs; fix bug in shell sort with size 1 array

### DIFF
--- a/demo.c
+++ b/demo.c
@@ -95,7 +95,7 @@ void run_tests(void) {
   }
 
   printf("stdlib qsort time:          %10.2f us per iteration\n", total_time / RUNS);
-#ifndef __linux__
+#if !defined(__linux__) && !defined(__CYGWIN__)
   srand48(SEED);
   total_time = 0.0;
 

--- a/multidemo.c
+++ b/multidemo.c
@@ -146,7 +146,7 @@ void run_tests(void) {
   }
 
   printf("stdlib qsort time: %.2f us per iteration\n", total_time / RUNS);
-#ifndef __linux__
+#if !defined(__linux__) && !defined(__CYGWIN__)
   srand48(SEED);
   total_time = 0.0;
 
@@ -298,7 +298,7 @@ void run_tests2(void) {
   }
 
   printf("stdlib qsort time: %.2f us per iteration\n", total_time / RUNS);
-#ifndef __linux__
+#if !defined(__linux__) && !defined(__CYGWIN__)
   srand48(SEED);
   total_time = 0.0;
 

--- a/sort.h
+++ b/sort.h
@@ -124,8 +124,8 @@ void TIM_SORT(SORT_TYPE *dst, const size_t size);
    http://en.wikipedia.org/wiki/Shell_sort
 */
 void SHELL_SORT(SORT_TYPE *dst, const size_t size) {
-  /* don't bother sorting an array of size 0 */
-  if (size == 0) {
+  /* don't bother sorting an array of size 0 or 1 */
+  if (size <= 1) {
     return;
   }
 

--- a/stresstest.c
+++ b/stresstest.c
@@ -211,7 +211,7 @@ int run_tests(int64_t *sizes, int sizes_cnt, int type) {
   double usec1, usec2, diff;
   printf("-------\nRunning tests with %s:\n-------\n", test_names[type]);
   TEST_STDLIB(qsort);
-#ifndef __linux__
+#if !defined(__linux__) && !defined(__CYGWIN__)
   TEST_STDLIB(heapsort);
   TEST_STDLIB(mergesort);
 #endif

--- a/stresstest.c
+++ b/stresstest.c
@@ -169,7 +169,7 @@ static void fill(int64_t *dst, const int size, int type) {
   printf("%-29s", "stdlib " #name ); \
   for (test = 0; test < sizes_cnt; test++) { \
     int64_t size = sizes[test]; \
-    int64_t dst[size]; \
+    int64_t dst[MAXSIZE]; \
     fill(dst, size, type); \
     usec1 = utime(); \
     name (dst, size, sizeof(int64_t), simple_cmp); \
@@ -191,7 +191,7 @@ static void fill(int64_t *dst, const int size, int type) {
   printf("%-29s", "sort.h " #name); \
   for (test = 0; test < sizes_cnt; test++) { \
     int64_t size = sizes[test]; \
-    int64_t dst[size]; \
+    int64_t dst[MAXSIZE]; \
     fill(dst, size, type); \
     usec1 = utime(); \
     sorter_ ## name (dst, size); \


### PR DESCRIPTION
Thanks to Kristján Jónasson for digging and finding all of these bugs!