### PR TITLE
Optimize Timsort merge

### DIFF
--- a/sort.h
+++ b/sort.h
@@ -847,11 +847,11 @@ static void TIM_SORT_RESIZE(TEMP_STORAGE_T *store, const size_t new_size) {
 
 static void TIM_SORT_MERGE(SORT_TYPE *dst, const TIM_SORT_RUN_T *stack, const int stack_curr,
                            TEMP_STORAGE_T *store) {
-  const int64_t A = stack[stack_curr - 2].length;
-  const int64_t B = stack[stack_curr - 1].length;
-  const int64_t curr = stack[stack_curr - 2].start;
+  const size_t A = stack[stack_curr - 2].length;
+  const size_t B = stack[stack_curr - 1].length;
+  const size_t curr = stack[stack_curr - 2].start;
   SORT_TYPE *storage;
-  int64_t i, j, k;
+  size_t i, j, k;
   TIM_SORT_RESIZE(store, MIN(A, B));
   storage = store->storage;
 
@@ -877,20 +877,21 @@ static void TIM_SORT_MERGE(SORT_TYPE *dst, const TIM_SORT_RUN_T *stack, const in
   } else {
     /* right merge */
     memcpy(storage, &dst[curr + A], B * sizeof(SORT_TYPE));
-    i = B - 1;
-    j = curr + A - 1;
+    i = B;
+    j = curr + A;
+    k = curr + A + B;
 
-    for (k = curr + A + B - 1; k >= curr; k--) {
-      if ((i >= 0) && (j >= curr)) {
-        if (SORT_CMP(dst[j], storage[i]) > 0) {
-          dst[k] = dst[j--];
+    while (k-- > curr) {
+      if ((i > 0) && (j > curr)) {
+        if (SORT_CMP(dst[j - 1], storage[i - 1]) > 0) {
+          dst[k] = dst[--j];
         } else {
-          dst[k] = storage[i--];
+          dst[k] = storage[--i];
         }
-      } else if (i >= 0) {
-        dst[k] = storage[i--];
+      } else if (i > 0) {
+        dst[k] = storage[--i];
       } else {
-        dst[k] = dst[j--];
+        dst[k] = dst[--j];
       }
     }
   }

--- a/sort.h
+++ b/sort.h
@@ -836,7 +836,7 @@ static void TIM_SORT_RESIZE(TEMP_STORAGE_T *store, const size_t new_size) {
 
     if (tempstore == NULL) {
       fprintf(stderr, "Error allocating temporary storage for tim sort: need %lu bytes",
-              sizeof(SORT_TYPE) * new_size);
+              (unsigned long)(sizeof(SORT_TYPE) * new_size));
       exit(1);
     }
 

--- a/sort.h
+++ b/sort.h
@@ -871,7 +871,7 @@ static void TIM_SORT_MERGE(SORT_TYPE *dst, const TIM_SORT_RUN_T *stack, const in
       } else if (i < A) {
         dst[k] = storage[i++];
       } else {
-        dst[k] = dst[j++];
+        break;
       }
     }
   } else {
@@ -891,7 +891,7 @@ static void TIM_SORT_MERGE(SORT_TYPE *dst, const TIM_SORT_RUN_T *stack, const in
       } else if (i > 0) {
         dst[k] = storage[--i];
       } else {
-        dst[k] = dst[--j];
+        break;
       }
     }
   }


### PR DESCRIPTION
Here's a second pull request with correct formatting and another minor optimization.

As I mentioned in the discussion of my previous PR, I also came up with a different approach that works directly on pointers when traversing the runs.

https://github.com/nwellnhof/sort/commit/a5245cc0dae89d2e8a5f49100f15622572bbb884

With simple sort functions, I get another 15% speed up on the register-starved x86-32 architecture. It makes the code harder to understand, though. If you like this approach, I can create another PR.