### PR TITLE
Homebrew gallop mode in timsort

### DIFF
--- a/sort.h
+++ b/sort.h
@@ -1036,11 +1036,6 @@ static void TIM_SORT_MERGE_LEFT(SORT_TYPE *A_src, SORT_TYPE *B_src, const size_t
 
 copyA:
   memcpy(&dst[pdst], &A_src[pa], (A - pa) * sizeof(SORT_TYPE));
-  /*
-  for (k=0;k<(A+B-1);++k){
-    assert(SORT_CMP(dst[k], dst[k+1]) <= 0);
-  }
-  */
   *min_gallop_p = min_gallop;
   return;
 }
@@ -1139,11 +1134,6 @@ static void TIM_SORT_MERGE_RIGHT(SORT_TYPE *A_src, SORT_TYPE *B_src, const size_
 
 copyB:
   memcpy(dst, B_src, (pb + 1) * sizeof(SORT_TYPE));
-  /*
-  for (k=0;k<(A+B-1);++k){
-    assert(SORT_CMP(dst[k], dst[k+1]) <= 0);
-  }
-  */
   *min_gallop_p = min_gallop;
   return;
 }
@@ -1159,13 +1149,6 @@ static void TIM_SORT_MERGE(SORT_TYPE *dst, const TIM_SORT_RUN_T *stack, const in
   size_t i, j, k;
   /* A[k-1] <= B[0] < A[k] */
   k = TIM_SORT_GALLOP(&dst[A_start], A, dst[B_start], 0, 1);
-
-  if (k != 0)
-  { assert(SORT_CMP(dst[A_start + k - 1], dst[B_start]) <= 0); }
-
-  if (k != A)
-  { assert(SORT_CMP(dst[B_start], dst[A_start + k]) < 0); }
-
   A_start += k;
   A -= k;
 
@@ -1176,13 +1159,6 @@ static void TIM_SORT_MERGE(SORT_TYPE *dst, const TIM_SORT_RUN_T *stack, const in
 
   /* B[k-1] < A[A-1] <= B[k] */
   k = TIM_SORT_GALLOP(&dst[B_start], B, dst[B_start - 1], B - 1, 0);
-
-  if (k != 0)
-  { assert(SORT_CMP(dst[B_start + k - 1], dst[B_start - 1]) < 0); }
-
-  if (k != B)
-  { assert(SORT_CMP(dst[B_start - 1], dst[B_start + k]) <= 0); }
-
   B = k;
   TIM_SORT_RESIZE(store, MIN(A, B));
   storage = store->storage;

--- a/sort.h
+++ b/sort.h
@@ -23,6 +23,10 @@
 #define TIM_SORT_STACK_SIZE 128
 #endif
 
+#ifndef TIM_SORT_MIN_GALLOP
+#define TIM_SORT_MIN_GALLOP 7
+#endif
+
 #ifndef SORT_SWAP
 #define SORT_SWAP(x,y) {SORT_TYPE _sort_swap_temp = (x); (x) = (y); (y) = _sort_swap_temp;}
 #endif
@@ -135,8 +139,11 @@ static __inline size_t rbnd(size_t len) {
 #define COUNT_RUN                      SORT_MAKE_STR(count_run)
 #define CHECK_INVARIANT                SORT_MAKE_STR(check_invariant)
 #define TIM_SORT                       SORT_MAKE_STR(tim_sort)
+#define TIM_SORT_GALLOP                SORT_MAKE_STR(tim_sort_gallop)
 #define TIM_SORT_RESIZE                SORT_MAKE_STR(tim_sort_resize)
 #define TIM_SORT_MERGE                 SORT_MAKE_STR(tim_sort_merge)
+#define TIM_SORT_MERGE_LEFT            SORT_MAKE_STR(tim_sort_merge_left)
+#define TIM_SORT_MERGE_RIGHT           SORT_MAKE_STR(tim_sort_merge_right)
 #define TIM_SORT_COLLAPSE              SORT_MAKE_STR(tim_sort_collapse)
 #define HEAP_SORT                      SORT_MAKE_STR(heap_sort)
 #define MEDIAN                         SORT_MAKE_STR(median)
@@ -847,60 +854,318 @@ static void TIM_SORT_RESIZE(TEMP_STORAGE_T *store, const size_t new_size) {
   }
 }
 
-static void TIM_SORT_MERGE(SORT_TYPE *dst, const TIM_SORT_RUN_T *stack, const int stack_curr,
-                           TEMP_STORAGE_T *store) {
-  const size_t A = stack[stack_curr - 2].length;
-  const size_t B = stack[stack_curr - 1].length;
-  const size_t curr = stack[stack_curr - 2].start;
-  SORT_TYPE *storage;
-  size_t i, j, k;
-  TIM_SORT_RESIZE(store, MIN(A, B));
-  storage = store->storage;
 
-  /* left merge */
-  if (A < B) {
-    memcpy(storage, &dst[curr], A * sizeof(SORT_TYPE));
-    i = 0;
-    j = curr + A;
+static size_t TIM_SORT_GALLOP(SORT_TYPE *dst, const size_t size, const SORT_TYPE key, size_t anchor,
+                              int right) {
+  int last_ofs = 0;
+  int ofs, max_ofs, cmp;
+  size_t  l, c, r;
+  cmp = SORT_CMP(key, dst[anchor]);
 
-    for (k = curr; k < curr + A + B; k++) {
-      if ((i < A) && (j < curr + A + B)) {
-        if (SORT_CMP(storage[i], dst[j]) <= 0) {
-          dst[k] = storage[i++];
-        } else {
-          dst[k] = dst[j++];
-        }
-      } else if (i < A) {
-        dst[k] = storage[i++];
-      } else {
+  if (cmp < 0 || (!right && cmp == 0)) {
+    /* short cut */
+    if (anchor == 0) {
+      return 0;
+    }
+
+    ofs = -1;
+    max_ofs = -anchor; /* ensure anchor+max_ofs is valid idx */
+  } else {
+    if (anchor == size - 1) {
+      return size;
+    }
+
+    ofs = 1;
+    max_ofs = size - anchor - 1;
+  }
+
+  for (;;) {
+    /* deal with overflow */
+    if (max_ofs / ofs <= 1) {
+      ofs = max_ofs;
+      break;
+    }
+
+    c = anchor + ofs;
+    /* right, 0<ofs:  dst[anchor+last_ofs] <=  key  <  dst[anchor+ofs]      */
+    /* left,  0<ofs:  dst[anchor+last_ofs] <   key  <= dst[anchor+ofs]      */
+    /* right, ofs<0:  dst[anchor+ofs]      <=  key  <  dst[anchor+last_ofs] */
+    /* left,  ofs<0:  dst[anchor+ofs]      <   key  <= dst[anchor+last_ofs] */
+    cmp = SORT_CMP(key, dst[c]);
+
+    if (0 < ofs) {
+      if ((right &&  cmp < 0) || (!right && cmp <= 0)) {
+        break;
+      }
+    } else {
+      if ((right && 0 <= cmp) || (!right && 0 < cmp)) {
         break;
       }
     }
-  } else {
-    /* right merge */
-    memcpy(storage, &dst[curr + A], B * sizeof(SORT_TYPE));
-    i = B;
-    j = curr + A;
-    k = curr + A + B;
 
-    while (k-- > curr) {
-      if ((i > 0) && (j > curr)) {
-        if (SORT_CMP(dst[j - 1], storage[i - 1]) > 0) {
-          dst[k] = dst[--j];
-        } else {
-          dst[k] = storage[--i];
+    last_ofs = ofs;
+    ofs = ofs << 1 + 1;
+  }
+
+  if (ofs < 0) {
+    /* key in region (l, r] */
+    l = anchor + ofs - 1;
+    r = anchor + last_ofs;
+  } else {
+    /* key in region [l, r) */
+    l = anchor + last_ofs;
+    r = anchor + ofs + 1;
+  }
+
+  while (1 < r - l) {
+    c = l + ((r - l) >> 1);
+    cmp = SORT_CMP(key, dst[c]);
+
+    if ((right && cmp < 0) || (!right && cmp <= 0)) {
+      r = c;
+    } else {
+      l = c;
+    }
+  }
+
+  return r;
+}
+
+
+
+static void TIM_SORT_MERGE_LEFT(SORT_TYPE *A_src, SORT_TYPE *B_src, const size_t A, const size_t B,
+                                SORT_TYPE* storage, int *min_gallop_p) {
+  size_t pdst, pa, pb, k;
+  int a_count, b_count;
+  int min_gallop = *min_gallop_p;
+  SORT_TYPE *dst = A_src;
+  memcpy(storage, dst, A * sizeof(SORT_TYPE));
+  A_src = storage;
+  pdst = pa = pb = 0;
+  /* first element must in B, otherwise skipped in the caller  */
+  dst[pdst++] = B_src[pb++];
+
+  if (B == 1) {
+    goto copyA;
+  }
+
+  for (;;) {
+    a_count = b_count = 0;
+
+    for (;;) {
+      if (SORT_CMP(A_src[pa], B_src[pb]) <= 0) {
+        dst[pdst++] = A_src[pa++];
+        ++a_count;
+        b_count = 0;
+
+        /* No need to check if pa == A because the last element must be in A
+         * so pb will reach to B first. You can check pa == A-1 and do
+         * some optimization if you wish.*/
+        if (min_gallop <= a_count) {
+          break;
         }
-      } else if (i > 0) {
-        dst[k] = storage[--i];
       } else {
+        dst[pdst++] = B_src[pb++];
+        ++b_count;
+        a_count = 0;
+
+        if (pb == B) {
+          goto copyA;
+        }
+
+        if (min_gallop <= b_count) {
+          break;
+        }
+      }
+    }
+
+    ++min_gallop;
+
+    for (;;) {
+      if (min_gallop != 0) {
+        min_gallop --;
+      }
+
+      k = TIM_SORT_GALLOP(&A_src[pa], A - pa, B_src[pb], 0, 1);
+      memcpy(&dst[pdst], &A_src[pa], k * sizeof(SORT_TYPE));
+      pdst += k;
+      pa += k;
+
+      if (a_count && k < TIM_SORT_MIN_GALLOP) {
+        ++min_gallop;
+        break;
+      }
+
+      k = TIM_SORT_GALLOP(&B_src[pb], B - pb, A_src[pa], 0, 0);
+      memmove(&dst[pdst], &B_src[pb], k * sizeof(SORT_TYPE));
+      pdst += k;
+      pb += k;
+
+      if (pb == B) {
+        goto copyA;
+      }
+
+      if (b_count && k < TIM_SORT_MIN_GALLOP) {
+        ++min_gallop;
         break;
       }
     }
   }
+
+copyA:
+  memcpy(&dst[pdst], &A_src[pa], (A - pa) * sizeof(SORT_TYPE));
+  /*
+  for (k=0;k<(A+B-1);++k){
+    assert(SORT_CMP(dst[k], dst[k+1]) <= 0);
+  }
+  */
+  *min_gallop_p = min_gallop;
+  return;
+}
+
+
+static void TIM_SORT_MERGE_RIGHT(SORT_TYPE *A_src, SORT_TYPE *B_src, const size_t A, const size_t B,
+                                 SORT_TYPE* storage, int *min_gallop_p) {
+  size_t k;
+  int pdst, pa, pb, a_count, b_count;
+  int min_gallop = *min_gallop_p;
+  SORT_TYPE *dst = A_src;
+  pa = A - 1;
+  pb = B - 1;
+  pdst = A + B - 1;
+  memcpy(storage, B_src, B * sizeof(SORT_TYPE));
+  B_src = storage;
+  /* last element must in A, otherwise skipped in the caller  */
+  dst[pdst--] = A_src[pa--];
+
+  if (A == 1) {
+    goto copyB;
+  }
+
+  for (;;) {
+    a_count = b_count = 0;
+
+    for (;;) {
+      if (SORT_CMP(A_src[pa], B_src[pb]) <= 0) {
+        dst[pdst--] = B_src[pb--];
+        ++b_count;
+        a_count = 0;
+
+        if (min_gallop <= b_count) {
+          break;
+        }
+
+        /* No need to check if pb == -1 because the first element must be in B
+         * so pa will reach to -1 first. You can check pb == 0 and do
+         * some optimization if you wish.*/
+      } else {
+        dst[pdst--] = A_src[pa--];
+        ++a_count;
+        b_count = 0;
+
+        if (pa == -1) {
+          goto copyB;
+        }
+
+        if (min_gallop <= a_count) {
+          break;
+        }
+      }
+    }
+
+    ++min_gallop;
+
+    for (;;) {
+      if (min_gallop != 0) {
+        min_gallop --;
+      }
+
+      k = TIM_SORT_GALLOP(A_src, pa + 1, B_src[pb], pa, 1);
+      /* Understand the margin by considering k==0 */
+      memmove(&dst[pb + k + 1], &A_src[k], (pa + 1 - k) * sizeof(SORT_TYPE));
+      pdst = pb + k;
+      pa = k - 1;
+
+      if (pa == -1) {
+        goto copyB;
+      }
+
+      if (a_count && pa + 1 - k < TIM_SORT_MIN_GALLOP) {
+        ++min_gallop;
+        break;
+      }
+
+      k = TIM_SORT_GALLOP(B_src, pb + 1, A_src[pa], pb, 0);
+      memcpy(&dst[pa + k + 1], &B_src[k], (pb + 1 - k) * sizeof(SORT_TYPE));
+      pdst = pa + k;
+      pb = k - 1;
+
+      if (b_count && pb + 1 - k < TIM_SORT_MIN_GALLOP) {
+        ++min_gallop;
+        break;
+      }
+    }
+  }
+
+copyB:
+  memcpy(dst, B_src, (pb + 1) * sizeof(SORT_TYPE));
+  /*
+  for (k=0;k<(A+B-1);++k){
+    assert(SORT_CMP(dst[k], dst[k+1]) <= 0);
+  }
+  */
+  *min_gallop_p = min_gallop;
+  return;
+}
+
+
+static void TIM_SORT_MERGE(SORT_TYPE *dst, const TIM_SORT_RUN_T *stack, const int stack_curr,
+                           TEMP_STORAGE_T *store, int* min_gallop_p) {
+  size_t A = stack[stack_curr - 2].length;
+  size_t B = stack[stack_curr - 1].length;
+  size_t A_start = stack[stack_curr - 2].start;
+  size_t B_start = stack[stack_curr - 1].start;
+  SORT_TYPE *storage;
+  size_t i, j, k;
+  /* A[k-1] <= B[0] < A[k] */
+  k = TIM_SORT_GALLOP(&dst[A_start], A, dst[B_start], 0, 1);
+  /*
+  if (k != 0)
+  { assert(SORT_CMP(dst[A_start + k - 1], dst[B_start]) <= 0); }
+
+  if (k != A)
+  { assert(SORT_CMP(dst[B_start], dst[A_start + k]) < 0); }
+  */
+  A_start += k;
+  A -= k;
+
+  if (A == 0) {
+    *min_gallop_p /= 2;
+    return;
+  }
+
+  /* B[k-1] < A[A-1] <= B[k] */
+  k = TIM_SORT_GALLOP(&dst[B_start], B, dst[B_start - 1], B - 1, 0);
+  /*
+  if (k != 0)
+  { assert(SORT_CMP(dst[B_start + k - 1], dst[B_start - 1]) < 0); }
+
+  if (k != B)
+  { assert(SORT_CMP(dst[B_start - 1], dst[B_start + k]) <= 0); }
+  */
+  B = k;
+  TIM_SORT_RESIZE(store, MIN(A, B));
+  storage = store->storage;
+
+  if (A < B) {
+    TIM_SORT_MERGE_LEFT(&dst[A_start], &dst[B_start], A, B, storage, min_gallop_p);
+  } else {
+    TIM_SORT_MERGE_RIGHT(&dst[A_start], &dst[B_start], A, B, storage, min_gallop_p);
+  }
 }
 
 static int TIM_SORT_COLLAPSE(SORT_TYPE *dst, TIM_SORT_RUN_T *stack, int stack_curr,
-                             TEMP_STORAGE_T *store, const size_t size) {
+                             TEMP_STORAGE_T *store, const size_t size, int* min_gallop_p) {
   while (1) {
     size_t A, B, C, D;
     int ABC, BCD, CD;
@@ -912,14 +1177,14 @@ static int TIM_SORT_COLLAPSE(SORT_TYPE *dst, TIM_SORT_RUN_T *stack, int stack_cu
 
     /* if this is the last merge, just do it */
     if ((stack_curr == 2) && (stack[0].length + stack[1].length == size)) {
-      TIM_SORT_MERGE(dst, stack, stack_curr, store);
+      TIM_SORT_MERGE(dst, stack, stack_curr, store, min_gallop_p);
       stack[0].length += stack[1].length;
       stack_curr--;
       break;
     }
     /* check if the invariant is off for a stack of 2 elements */
     else if ((stack_curr == 2) && (stack[0].length <= stack[1].length)) {
-      TIM_SORT_MERGE(dst, stack, stack_curr, store);
+      TIM_SORT_MERGE(dst, stack, stack_curr, store, min_gallop_p);
       stack[0].length += stack[1].length;
       stack_curr--;
       break;
@@ -948,13 +1213,13 @@ static int TIM_SORT_COLLAPSE(SORT_TYPE *dst, TIM_SORT_RUN_T *stack, int stack_cu
 
     /* left merge */
     if (BCD && !CD) {
-      TIM_SORT_MERGE(dst, stack, stack_curr - 1, store);
+      TIM_SORT_MERGE(dst, stack, stack_curr - 1, store, min_gallop_p);
       stack[stack_curr - 3].length += stack[stack_curr - 2].length;
       stack[stack_curr - 2] = stack[stack_curr - 1];
       stack_curr--;
     } else {
       /* right merge */
-      TIM_SORT_MERGE(dst, stack, stack_curr, store);
+      TIM_SORT_MERGE(dst, stack, stack_curr, store, min_gallop_p);
       stack[stack_curr - 2].length += stack[stack_curr - 1].length;
       stack_curr--;
     }
@@ -969,7 +1234,8 @@ static __inline int PUSH_NEXT(SORT_TYPE *dst,
                               const size_t minrun,
                               TIM_SORT_RUN_T *run_stack,
                               size_t *stack_curr,
-                              size_t *curr) {
+                              size_t *curr,
+                              int *min_gallop_p) {
   size_t len = COUNT_RUN(dst, *curr, size);
   size_t run = minrun;
 
@@ -990,7 +1256,7 @@ static __inline int PUSH_NEXT(SORT_TYPE *dst,
   if (*curr == size) {
     /* finish up */
     while (*stack_curr > 1) {
-      TIM_SORT_MERGE(dst, run_stack, *stack_curr, store);
+      TIM_SORT_MERGE(dst, run_stack, *stack_curr, store, min_gallop_p);
       run_stack[*stack_curr - 2].length += run_stack[*stack_curr - 1].length;
       (*stack_curr)--;
     }
@@ -1012,6 +1278,7 @@ void TIM_SORT(SORT_TYPE *dst, const size_t size) {
   TIM_SORT_RUN_T run_stack[TIM_SORT_STACK_SIZE];
   size_t stack_curr = 0;
   size_t curr = 0;
+  int min_gallop = TIM_SORT_MIN_GALLOP;
 
   /* don't bother sorting an array of size 1 */
   if (size <= 1) {
@@ -1030,25 +1297,25 @@ void TIM_SORT(SORT_TYPE *dst, const size_t size) {
   store->alloc = 0;
   store->storage = NULL;
 
-  if (!PUSH_NEXT(dst, size, store, minrun, run_stack, &stack_curr, &curr)) {
+  if (!PUSH_NEXT(dst, size, store, minrun, run_stack, &stack_curr, &curr, &min_gallop)) {
     return;
   }
 
-  if (!PUSH_NEXT(dst, size, store, minrun, run_stack, &stack_curr, &curr)) {
+  if (!PUSH_NEXT(dst, size, store, minrun, run_stack, &stack_curr, &curr, &min_gallop)) {
     return;
   }
 
-  if (!PUSH_NEXT(dst, size, store, minrun, run_stack, &stack_curr, &curr)) {
+  if (!PUSH_NEXT(dst, size, store, minrun, run_stack, &stack_curr, &curr, &min_gallop)) {
     return;
   }
 
   while (1) {
     if (!CHECK_INVARIANT(run_stack, stack_curr)) {
-      stack_curr = TIM_SORT_COLLAPSE(dst, run_stack, stack_curr, store, size);
+      stack_curr = TIM_SORT_COLLAPSE(dst, run_stack, stack_curr, store, size, &min_gallop);
       continue;
     }
 
-    if (!PUSH_NEXT(dst, size, store, minrun, run_stack, &stack_curr, &curr)) {
+    if (!PUSH_NEXT(dst, size, store, minrun, run_stack, &stack_curr, &curr, &min_gallop)) {
       return;
     }
   }


### PR DESCRIPTION
This PR reimplements gallop mode in timsort (#49) according to the idea of the algorithm without any reference to the original CPython code (#50)
Benchmark between this implementation and the original timsort (otim sort or osortertim_sort) is shown below (over 1000 tests):
### Array size 1600
```
             tim sort -- stable
            otim sort -- stable
-------
Running tests with random numbers:
-------
sort.h sortertim_sort         - ok,    61077.0 usec
sort.h osortertim_sort        - ok,    54048.0 usec
-------
Running tests with same number:
-------
sort.h sortertim_sort         - ok,      579.0 usec
sort.h osortertim_sort        - ok,      660.0 usec
-------
Running tests with sorted numbers:
-------
sort.h sortertim_sort         - ok,      454.0 usec
sort.h osortertim_sort        - ok,      441.0 usec
-------
Running tests with sorted blocks of length 10:
-------
sort.h sortertim_sort         - ok,    59462.0 usec
sort.h osortertim_sort        - ok,    57017.0 usec
-------
Running tests with sorted blocks of length 100:
-------
sort.h sortertim_sort         - ok,    20349.0 usec
sort.h osortertim_sort        - ok,    16217.0 usec
-------
Running tests with sorted blocks of length 10000:
-------
sort.h sortertim_sort         - ok,      488.0 usec
sort.h osortertim_sort        - ok,      536.0 usec
-------
Running tests with swapped size/2 pairs:
-------
sort.h sortertim_sort         - ok,     1137.0 usec
sort.h osortertim_sort        - ok,     2155.0 usec
-------
Running tests with swapped size/8 pairs:
-------
sort.h sortertim_sort         - ok,     1795.0 usec
sort.h osortertim_sort        - ok,     2253.0 usec
```

### Array size 16000
```
             tim sort -- stable
            otim sort -- stable
-------
Running tests with random numbers:
-------
sort.h sortertim_sort         - ok,   655363.0 usec
sort.h osortertim_sort        - ok,   692661.0 usec
-------
Running tests with same number:
-------
sort.h sortertim_sort         - ok,     5345.0 usec
sort.h osortertim_sort        - ok,     5032.0 usec
-------
Running tests with sorted numbers:
-------
sort.h sortertim_sort         - ok,     6636.0 usec
sort.h osortertim_sort        - ok,     6113.0 usec
-------
Running tests with sorted blocks of length 10:
-------
sort.h sortertim_sort         - ok,   679422.0 usec
sort.h osortertim_sort        - ok,   658775.0 usec
-------
Running tests with sorted blocks of length 100:
-------
sort.h sortertim_sort         - ok,   326854.0 usec
sort.h osortertim_sort        - ok,   348215.0 usec
-------
Running tests with sorted blocks of length 10000:
-------
sort.h sortertim_sort         - ok,    28606.0 usec
sort.h osortertim_sort        - ok,    27756.0 usec
-------
Running tests with swapped size/2 pairs:
-------
sort.h sortertim_sort         - ok,     7702.0 usec
sort.h osortertim_sort        - ok,    17202.0 usec
-------
Running tests with swapped size/8 pairs:
-------
sort.h sortertim_sort         - ok,     7563.0 usec
sort.h osortertim_sort        - ok,    17550.0 usec
```
Again, conclusion seems unchanged -- some overhead and decent improvement with swapped pairs.
