### PR TITLE
optimize merge sort

### DIFF
--- a/sort.h
+++ b/sort.h
@@ -1242,23 +1242,23 @@ void MERGE_SORT_RECURSIVE(SORT_TYPE *newdst, SORT_TYPE *dst, const size_t size) 
   if (SORT_CMP(dst[middle - 1], dst[middle]) <= 0)
   { return; }
 
+  SORT_TYPE_CPY(newdst, dst, middle);
+
   for (; i < middle && j < size; ++out) {
-    if (SORT_CMP(dst[i], dst[j]) <= 0) {
-      newdst[out] = dst[i++];
+    if (SORT_CMP(newdst[i], dst[j]) <= 0) {
+      dst[out] = newdst[i++];
     } else {
-      newdst[out] = dst[j++];
+      dst[out] = dst[j++];
     }
   }
 
   for (; i < middle; ++out) {
-    newdst[out] = dst[i++];
+    dst[out] = newdst[i++];
   }
 
   for (; j < size; ++out) {
-    newdst[out] = dst[j++];
+    dst[out] = dst[j++];
   }
-
-  SORT_TYPE_CPY(dst, newdst, size);
 }
 
 /* Standard merge sort */
@@ -1275,7 +1275,7 @@ void MERGE_SORT(SORT_TYPE *dst, const size_t size) {
     return;
   }
 
-  newdst = SORT_NEW_BUFFER(size);
+  newdst = SORT_NEW_BUFFER(size / 2);
   MERGE_SORT_RECURSIVE(newdst, dst, size);
   SORT_DELETE_BUFFER(newdst);
 }

--- a/sort.h
+++ b/sort.h
@@ -1239,22 +1239,23 @@ void MERGE_SORT_RECURSIVE(SORT_TYPE *newdst, SORT_TYPE *dst, const size_t size) 
   MERGE_SORT_RECURSIVE(newdst, dst, middle);
   MERGE_SORT_RECURSIVE(newdst, &dst[middle], size - middle);
 
-  while (out != size) {
-    if (i < middle) {
-      if (j < size) {
-        if (SORT_CMP(dst[i], dst[j]) <= 0) {
-          newdst[out] = dst[i++];
-        } else {
-          newdst[out] = dst[j++];
-        }
-      } else {
-        newdst[out] = dst[i++];
-      }
+  if (SORT_CMP(dst[middle - 1], dst[middle]) <= 0)
+  { return; }
+
+  for (; i < middle && j < size; ++out) {
+    if (SORT_CMP(dst[i], dst[j]) <= 0) {
+      newdst[out] = dst[i++];
     } else {
       newdst[out] = dst[j++];
     }
+  }
 
-    out++;
+  for (; i < middle; ++out) {
+    newdst[out] = dst[i++];
+  }
+
+  for (; j < size; ++out) {
+    newdst[out] = dst[j++];
   }
 
   SORT_TYPE_CPY(dst, newdst, size);

--- a/sort.h
+++ b/sort.h
@@ -1255,10 +1255,6 @@ void MERGE_SORT_RECURSIVE(SORT_TYPE *newdst, SORT_TYPE *dst, const size_t size) 
   for (; i < middle; ++out) {
     dst[out] = newdst[i++];
   }
-
-  for (; j < size; ++out) {
-    dst[out] = dst[j++];
-  }
 }
 
 /* Standard merge sort */


### PR DESCRIPTION
save about 10% time
only alloc `length/2` size of buffer
O(n) if already sorted