### PR TITLE
fix off-by-one in stresstest

### DIFF
--- a/stresstest.c
+++ b/stresstest.c
@@ -118,9 +118,9 @@ static void fill_swapped(int64_t *dst, const int size, const int swapped_cnt) {
 
   for (i = 0; i < swapped_cnt; i++) {
     ind1 = lrand48();
-    RAND_RANGE(ind1, 0, size);
+    RAND_RANGE(ind1, 0, size-1);
     ind2 = lrand48();
-    RAND_RANGE(ind2, 0, size);
+    RAND_RANGE(ind2, 0, size-1);
     tmp = dst[ind1];
     dst[ind1] = dst[ind2];
     dst[ind2] = tmp;


### PR DESCRIPTION
fix off-by-one in stresstest code
array index must be between 0 and <array size> - 1, not between 0 and <array size>