### PR TITLE
docs: fix simple typo, inlineing -> inlining

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ such as inlining functions, using fast arithmetic, and avoiding pointers.
 
 ## __inline
 
-The proper, C89 way to do inlineing is to mark a function as `__inline` --
+The proper, C89 way to do inlining is to mark a function as `__inline` --
 this is useful for comparisons and other small functions that are used often.
 
 ## Make sure tests pass


### PR DESCRIPTION
There is a small typo in CONTRIBUTING.md.

Should read `inlining` rather than `inlineing`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md